### PR TITLE
fix: removed trigger for pull request against main branch

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,8 +3,6 @@ name: Docker Build
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
the GitHub Actions workflow will trigger when a pull request is created or updated against the main branch, even if the pull request is not merged